### PR TITLE
fix git link in README-PROD.md

### DIFF
--- a/README-PROD.md
+++ b/README-PROD.md
@@ -5,7 +5,7 @@ This is the documentation for going to test/production.
 ## Clone the repository
 
 ```
-git clone https://git.t-systems-mms.eu/scm/saec/devday_hp.git
+git clone https://github.com/devdaydresden/devday_website.git
 ```
 
 ## Build the images


### PR DESCRIPTION
should this also be changed to explicitly checkout master? (since development is the default branch)
Or should we rather change the default branch to master?