### PR TITLE
Reduce shutdown time with dumb-init

### DIFF
--- a/docker/app/Dockerfile-dev
+++ b/docker/app/Dockerfile-dev
@@ -30,15 +30,16 @@ RUN apk --no-cache add \
   bash \
   build-base \
   curl \
+  dumb-init \
   gcc \
   gettext \
   git \
+  jpeg-dev \
   libffi-dev \
   linux-headers \
   musl-dev \
-  zlib-dev \
   postgresql-dev \
-  jpeg-dev
+  zlib-dev
 RUN pip install pipenv
 
 VOLUME /srv/devday /srv/devday/devday/media /srv/devday/devday/static
@@ -49,4 +50,4 @@ RUN pipenv install --system --deploy --ignore-pipfile --dev
 
 WORKDIR /srv/devday/devday
 
-ENTRYPOINT ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+ENTRYPOINT ["dumb-init", "python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker/app/Dockerfile-prod
+++ b/docker/app/Dockerfile-prod
@@ -37,6 +37,7 @@ WORKDIR /srv/devday
 RUN apk --no-cache add \
     build-base \
     ca-certificates \
+    dumb-init \
     gcc \
     gettext \
     jpeg \
@@ -68,4 +69,4 @@ RUN apk --no-cache add \
     postgresql-dev \
     zlib-dev
 
-CMD /srv/devday/start-application.sh
+ENTRYPOINT ["dumb-init", "/srv/devday/start-application.sh"]


### PR DESCRIPTION
Timings before:

./run.sh compose stop app  0,58s user 0,11s system 6% cpu 11,186 total
./run.sh compose down -v  0,71s user 0,10s system 6% cpu 12,194 total

after:

./run.sh compose down -v  0,65s user 0,07s system 33% cpu 2,136 total
./run.sh compose stop app  0,63s user 0,07s system 57% cpu 1,234 total

Fixes #31