### PR TITLE
Fix error pages

### DIFF
--- a/devday/devday/templates/400.html
+++ b/devday/devday/templates/400.html
@@ -1,31 +1,16 @@
 {% extends "base.html" %}
 {% load static i18n %}
-{% block title %}Dev Day 2018 // Let code rule - {% trans "Bad Request" %}{% endblock %}
-{% block navigation %}
-    <div class="container-fluid">
-        <div class="{% block promo_classes %}row promo site{% endblock %}">
-            <nav class="navbar navbar-default">
-                <div class="navbar-header">
-                    <a href="{% url "pages-root" %}"><img src="{% static "img/logo-19.svg" %}" alt="Dev Day 2018"></a>
-                </div>
-                <div class="collapse navbar-collapse navbar-desktop">
-                    <ul class="nav navbar-nav navbar-right">
-                    </ul>
-                </div>
-                <div class="collapse navbar-collapse navbar-mobile">
-                </div>
-            </nav>
-            <div class="col-xs-12 call-to-action">
-                <img src="{% static "images/claim-2x.png" %}" alt="Let Code Rule"/>
+{% block title %}{{ block.super }} // {% trans "Bad Request" %}{% endblock %}
+{% block top_menu %}{% endblock %}
+{% block content_block_1 %}
+    <div class="container">
+        <div class="row ">
+            <div class="content-area">
+                <h1>Oops</h1>
+                <h2>{% trans "Bad Request" %}</h2>
             </div>
         </div>
     </div>
 {% endblock %}
-{% block content %}
-    <div class="row">
-        <div class="col-md-12 col-xs-12 col-lg-10 offset-lg-1 info-area error-400" id="info-area">
-            <h1>Oops</h1>
-            <h2>{% trans "Bad Request" %}</h2>
-        </div>
-    </div>
-{% endblock %}
+{% block content_block_2 %}{% endblock %}
+{% block content_block_3 %}{% endblock %}

--- a/devday/devday/templates/404.html
+++ b/devday/devday/templates/404.html
@@ -1,31 +1,16 @@
 {% extends "base.html" %}
 {% load static i18n %}
-{% block title %}Dev Day 2018 // Let code rule - {% trans "Page not found" %}{% endblock %}
-{% block navigation %}
-    <div class="container-fluid">
-        <div class="{% block promo_classes %}row promo site{% endblock %}">
-            <nav class="navbar navbar-default">
-                <div class="navbar-header">
-                    <a href="{% url "pages-root" %}"><img src="{% static "images/logo.png" %}" alt="Dev Day 2018"></a>
-                </div>
-                <div class="collapse navbar-collapse navbar-desktop">
-                    <ul class="nav navbar-nav navbar-right">
-                    </ul>
-                </div>
-                <div class="collapse navbar-collapse navbar-mobile">
-                </div>
-            </nav>
-            <div class="col-xs-12 call-to-action">
-                <img src="{% static "images/claim-2x.png" %}" alt="Let Code Rule"/>
+{% block title %}{{ block.super }} // {% trans "Page not found" %}{% endblock %}
+{% block top_menu %}{% endblock %}
+{% block content_block_1 %}
+    <div class="container">
+        <div class="row ">
+            <div class="content-area">
+                <h1>Oops you're in outer space</h1>
+                <h2>{% trans "Page not found" %}</h2>
             </div>
         </div>
     </div>
 {% endblock %}
-{% block content %}
-    <div class="row">
-        <div class="col-md-12 col-xs-12 col-lg-10 offset-lg-1 info-area error-404" id="info-area">
-            <h1>Oops you're in outer space</h1>
-            <h2>{% trans "Page not found" %}</h2>
-        </div>
-    </div>
-{% endblock %}
+{% block content_block_2 %}{% endblock %}
+{% block content_block_3 %}{% endblock %}

--- a/devday/devday/templates/base.html
+++ b/devday/devday/templates/base.html
@@ -18,7 +18,8 @@
     {% block navigation %}
         <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav" data-ui-navbar>
             <div class="container">
-                <a href="{% url 'pages-root' %}" class="navbar-brand"><img src="{% static "img/logo-19.svg" %}" alt="{{ event.title }}"></a>
+                <a href="{% url 'pages-root' %}" class="navbar-brand"><img src="{% static "img/logo-19.svg" %}" alt="{{ current_event.title }}"></a>
+                {% block top_menu %}
                 <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>
@@ -27,6 +28,7 @@
                       {% include "base_menu.html" %}
                     </ul>
                 </div>
+                {% endblock %}
             </div>
         </nav>
     {% endblock navigation %}
@@ -72,6 +74,7 @@
     </div>
     {% endblock content_block_2 %}
 
+    {% block content_block_3 %}
     {% if sponsoring_open or has_change_permissions %}
     <div class="stripe c-gray{% if not sponsoring_open %} visible-to-editor-only{% endif %}">
         <div class="container">
@@ -94,6 +97,7 @@
         </div>
     </div>
     {% endif %}
+    {% endblock %}
 
     <footer>
         <img src="{% static 'images/seco-logo.svg' %}" alt="Software Engineering Community"> | <a href="{% page_url 'imprint' %}">IMPRESSUM</a>


### PR DESCRIPTION
Adapt error pages to new base template structure. Add more block markers to
base template to allow excluding navigation menu and sponsoring block from
templates derived from base.html.

Fixes #36