### PR TITLE
Improve prod backup

### DIFF
--- a/prod.sh
+++ b/prod.sh
@@ -21,14 +21,13 @@ fi
 
 case "$cmd" in
   backup)
-    $DOCKER_COMPOSE up -d
     echo "*** Running backup"
-    # sleep a few seconds to wait for the database to finish start
-    sleep 5
+    $DOCKER_COMPOSE up -d db
+    $DOCKER_COMPOSE exec db sh -c 'while ! pg_isready; do sleep 1; done'
     BACKUPDATA=$(date +%Y%m%d-%H%M%S%z)
     mkdir -p backup
     $DOCKER_COMPOSE exec db pg_dump -U postgres devday | gzip > "backup/prod-db-${BACKUPDATA}.sql.gz"
-    $DOCKER_COMPOSE exec -T app tar cz -C /srv/devday/media . > "backup/prod-media-${BACKUPDATA}.tar.gz"
+    $DOCKER_COMPOSE run --rm --no-deps -T app tar cz -C /srv/devday/media . > "backup/prod-media-${BACKUPDATA}.tar.gz"
     ;;
   build)
     # Relevant for production/test environments with full vault setup


### PR DESCRIPTION
- use pg_isready to wait for database startup
- run media backup as a one-off command in a new app container to avoid
  starting the application and running potentially existing migrations

Fixes #34