### PR TITLE
Implement user setup and password change feature

### DIFF
--- a/devday/attendee/admin.py
+++ b/devday/attendee/admin.py
@@ -1,14 +1,26 @@
 from django.contrib import admin
-from django.contrib.admin import ModelAdmin
 from django.contrib.auth.admin import UserAdmin
 from django.utils.translation import ugettext_lazy as _
 
-from .forms import DevDayUserCreationForm, DevDayUserChangeForm
-from .models import DevDayUser
+from .forms import AttendeeInlineForm, DevDayUserCreationForm, DevDayUserChangeForm
+from .models import DevDayUser, Attendee
 
 
-class AttendeeAdmin(ModelAdmin):
-    list_display = ['__str__']
+@admin.register(Attendee)
+class AttendeeAdmin(admin.ModelAdmin):
+    list_display = ('__str__', 'user', 'event')
+    fields = ('user', 'source', 'event')
+    list_filter = ('event',)
+    search_fields = ('user__email', 'user__first_name', 'user__last_name')
+    ordering = ('event__title', 'user__email')
+
+
+class AttendeeInline(admin.TabularInline):
+    model = Attendee
+    fields = (('event', 'source'),)
+    ordering = ('event__title',)
+    extra = 0
+    form = AttendeeInlineForm
 
 
 @admin.register(DevDayUser)
@@ -22,7 +34,7 @@ class DevDayUserAdmin(UserAdmin):
         (_('Permissions'), {'fields': ('is_active', 'is_staff', 'is_superuser',
                                        'groups', 'user_permissions')}),
         (_('Important dates'), {'fields': ('last_login', 'date_joined', 'contact_permission_date')}),
-        (_('Miscellaneous'), {'fields': ('twitter_handle', 'phone', 'position', 'organization')})
+        (_('Miscellaneous'), {'fields': ('twitter_handle', 'phone', 'position', 'organization')}),
     )
     add_fieldsets = (
         (None, {
@@ -33,3 +45,4 @@ class DevDayUserAdmin(UserAdmin):
     ordering = ('email',)
     add_form = DevDayUserCreationForm
     form = DevDayUserChangeForm
+    inlines = (AttendeeInline,)

--- a/devday/attendee/admin.py
+++ b/devday/attendee/admin.py
@@ -1,21 +1,35 @@
 from django.contrib import admin
 from django.contrib.admin import ModelAdmin
+from django.contrib.auth.admin import UserAdmin
+from django.utils.translation import ugettext_lazy as _
 
-from .models import Attendee, DevDayUser
+from .forms import DevDayUserCreationForm, DevDayUserChangeForm
+from .models import DevDayUser
 
 
 class AttendeeAdmin(ModelAdmin):
     list_display = ['__str__']
 
 
-class DevDayUserAdmin(ModelAdmin):
-    list_display = ('title', 'twitter_handle')
-    search_fields = ('first_name', 'last_name', 'email')
-    list_filter = ('attendees__event', 'is_active')
-
-    def title(self, obj):
-        return u"{} {} <{}>".format(obj.first_name, obj.last_name, obj.email)
-
-
-admin.site.register(DevDayUser, DevDayUserAdmin)
-admin.site.register(Attendee, AttendeeAdmin)
+@admin.register(DevDayUser)
+class DevDayUserAdmin(UserAdmin):
+    list_display = ('email', 'first_name', 'last_name', 'is_staff', 'twitter_handle')
+    search_fields = ('first_name', 'last_name', 'email', 'twitter_handle', 'organization')
+    list_filter = ('attendees__event', 'is_active', 'is_staff')
+    fieldsets = (
+        (None, {'fields': ('email', 'password')}),
+        (_('Personal info'), {'fields': ('first_name', 'last_name')}),
+        (_('Permissions'), {'fields': ('is_active', 'is_staff', 'is_superuser',
+                                       'groups', 'user_permissions')}),
+        (_('Important dates'), {'fields': ('last_login', 'date_joined', 'contact_permission_date')}),
+        (_('Miscellaneous'), {'fields': ('twitter_handle', 'phone', 'position', 'organization')})
+    )
+    add_fieldsets = (
+        (None, {
+            'classes': ('wide',),
+            'fields': ('email', 'password1', 'password2'),
+        }),
+    )
+    ordering = ('email',)
+    add_form = DevDayUserCreationForm
+    form = DevDayUserChangeForm

--- a/devday/attendee/forms.py
+++ b/devday/attendee/forms.py
@@ -82,6 +82,14 @@ class DevDayUserChangeForm(UserChangeForm):
         field_classes = {'email': forms.EmailField}
 
 
+class AttendeeInlineForm(ModelForm):
+    class Meta:
+        model = Attendee
+        fields = ['event', 'source']
+        widgets = {
+            'source': forms.Textarea(attrs={'cols': 40, 'rows': 1})
+        }
+
 
 class AttendeeSourceForm(ModelForm):
     class Meta:


### PR DESCRIPTION
This commit takes adapted versions of the user management forms from
django.contrib.auth.forms and django.contrib.auth.admin to enable
creation and updating of users as well as administrative password reset
functionality.

Fixes #44