### PR TITLE
Fix public speaker view

### DIFF
--- a/devday/talk/views.py
+++ b/devday/talk/views.py
@@ -337,7 +337,7 @@ class SpeakerPublic(DetailView):
 
     def get_queryset(self):
         return super(SpeakerPublic, self).get_queryset().filter(
-            talk__track__isnull=False).prefetch_related('talk_set')
+            talk__track__isnull=False).prefetch_related('talk_set').distinct()
 
     def get_context_data(self, **kwargs):
         context = super(SpeakerPublic, self).get_context_data(**kwargs)


### PR DESCRIPTION
The public speaker view could not handle speakers that presented more than one
session at an event. This commit adds a set of tests for
talk.views.SpeakerPublic and fixes the bug by adding .distinct() to the view's
queryset.

Fixes #42