### PR TITLE
Disable file logging for dev

### DIFF
--- a/devday/devday/settings/base.py
+++ b/devday/devday/settings/base.py
@@ -291,15 +291,10 @@ LOGGING = {
         }
     },
     'handlers': {
-        'file': {
-            'class': 'logging.FileHandler',
-            'filename': os.path.join(BASE_DIR, 'logs', 'devday.log'),
-            'formatter': 'simple',
-            'level': 'INFO',
-        },
         'console': {
             'class': 'logging.StreamHandler',
             'formatter': 'simple',
+            'level': 'INFO'
         }
     },
     'loggers': {}

--- a/devday/devday/settings/dev.py
+++ b/devday/devday/settings/dev.py
@@ -24,7 +24,7 @@ for logname in [
     'devday', 'attendee', 'event', 'speaker', 'talk', 'twitterfeed'
 ]:
     LOGGING['loggers'][logname] = {
-        'handlers': ['console', 'file'],
+        'handlers': ['console'],
         'level': 'INFO',
     }
 

--- a/devday/devday/settings/prod.py
+++ b/devday/devday/settings/prod.py
@@ -40,6 +40,12 @@ LOGGING['handlers'].update({
         'include_html': True,
         'filters': ['require_debug_false'],
     },
+    'file': {
+        'class': 'logging.FileHandler',
+        'filename': os.path.join(BASE_DIR, 'logs', 'devday.log'),
+        'formatter': 'simple',
+        'level': 'INFO',
+    },
 })
 
 for logname in [

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,8 +28,4 @@ services:
     volumes:
       - "devday_media:/srv/devday/media"
       - "devday_static:/srv/devday/static"
-      - "devday_logs:/srv/devday/logs"
       - "./devday:/srv/devday"
-
-volumes:
-  devday_logs:


### PR DESCRIPTION
dev images use a console logger that can be followed by ./run.sh logs.
The file logger does not make much sense for local development. This
commit moves the file logger to the prod settings and removes the unused
devday_logs mount in the dev application container.