### PR TITLE
 Add new CMS template with no CTA

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,7 @@ django-registration = "*"
 "html2text" = "*"
 lorem = "*"
 luhn = "*"
+stringcase = "*"
 django-ordered-model = "<3.0"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b43a1b5904f5e2a3ece1cd6b56ed381c9a79371b4a17975ae54b3ffbd6a90fad"
+            "sha256": "d8d69f7d84263945f55b725bee1887ab25f211891536155a9406197ce14a9675"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -170,11 +170,10 @@
         },
         "djangocms-admin-style": {
             "hashes": [
-                "sha256:7c802e9b9e9b1cf9e36b2d1368faaae6bbd6cefaf6a55f069ec373a91338fae8",
-                "sha256:7f7452f0d6b9d45f99949e8dd2f7a0fcc242d2134d6cec088ed2b3457e2c7954"
+                "sha256:c194371260121f48f188e237c5d642b75657594374d21a18b7d77e89e10eb3ee"
             ],
             "index": "pypi",
-            "version": "==1.2.8"
+            "version": "==1.2.9"
         },
         "djangocms-attributes-field": {
             "hashes": [
@@ -375,10 +374,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:642253af8eae734d1509fc6ac9c1aee5e5b69d76392660889979b9870610a46b",
-                "sha256:91e3ccf2c344ffaa6defba1ce7f38f97026943f675b7703f44789768e4cb0ece"
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
             ],
-            "version": "==2018.6"
+            "version": "==2018.7"
         },
         "requests": {
             "hashes": [
@@ -395,6 +394,13 @@
             ],
             "version": "==1.11.0"
         },
+        "stringcase": {
+            "hashes": [
+                "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008"
+            ],
+            "index": "pypi",
+            "version": "==1.2.0"
+        },
         "unidecode": {
             "hashes": [
                 "sha256:280a6ab88e1f2eb5af79edff450021a0d3f0448952847cd79677e55e58bad051",
@@ -407,7 +413,6 @@
                 "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
                 "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*'",
             "version": "==1.24"
         }
     },
@@ -571,10 +576,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:642253af8eae734d1509fc6ac9c1aee5e5b69d76392660889979b9870610a46b",
-                "sha256:91e3ccf2c344ffaa6defba1ce7f38f97026943f675b7703f44789768e4cb0ece"
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
             ],
-            "version": "==2018.6"
+            "version": "==2018.7"
         },
         "requests": {
             "hashes": [
@@ -603,7 +608,6 @@
                 "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
                 "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*'",
             "version": "==1.24"
         }
     }

--- a/devday/devday/locale/de/LC_MESSAGES/django.po
+++ b/devday/devday/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: devday\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-01 15:50+0000\n"
+"POT-Creation-Date: 2018-11-02 10:17+0000\n"
 "PO-Revision-Date: 2018-10-25 16:47+0200\n"
 "Last-Translator: Jan Dittberner <jan@dittberner.info>\n"
 "Language-Team: Jan Dittberner <jan.dittberner@t-systems.com>\n"
@@ -123,27 +123,39 @@ msgstr "Test-Email an mich selbst senden"
 msgid "Send Email To Selected Recipients"
 msgstr "Email an ausgewählte Empfängergruppe senden"
 
-#: devday/settings/base.py:121 devday/settings/base.py:208
+#: devday/settings/base.py:122 devday/settings/base.py:210
 msgid "de"
 msgstr "de"
 
-#: devday/settings/base.py:137
+#: devday/settings/base.py:138
 msgid "row"
 msgstr "row"
 
-#: devday/settings/base.py:138
+#: devday/settings/base.py:139
 msgid "container"
 msgstr "container"
 
-#: devday/settings/base.py:139
+#: devday/settings/base.py:140
 msgid "col-xs-12"
 msgstr "col-xs-12"
 
-#: devday/settings/base.py:140
+#: devday/settings/base.py:141
 msgid "col-md-12"
 msgstr "col-md-12"
 
-#: devday/settings/base.py:209
+#: devday/settings/base.py:146
+msgid "Dev Day Page"
+msgstr "Dev-Day-Seite"
+
+#: devday/settings/base.py:147
+msgid "Dev Day Page with Call to Action area"
+msgstr "Dev-Day-Seite mit Call-to-Action-Bereich"
+
+#: devday/settings/base.py:148
+msgid "Dev Day Home Page"
+msgstr "Dev-Day-Homepage"
+
+#: devday/settings/base.py:211
 msgid "en"
 msgstr "en"
 

--- a/devday/devday/settings/base.py
+++ b/devday/devday/settings/base.py
@@ -17,6 +17,7 @@ import mimetypes
 from requests import get
 
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.translation import ugettext_lazy as _
 
 
 def gettext(s):
@@ -142,8 +143,9 @@ DJANGOCMS_STYLE_CHOICES = (
 DJANGOCMS_PICTURE_RESPONSIVE_IMAGES = False
 
 CMS_TEMPLATES = (
-    ('devday.html', 'Devday'),
-    ('devday_index.html', 'Dev Day Startseite'),
+    ('devday_no_cta.html', _('Dev Day Page')),
+    ('devday.html', _('Dev Day Page with Call to Action area')),
+    ('devday_index.html', _('Dev Day Home Page')),
 )
 CMS_PERMISSION = True
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
@@ -295,7 +297,8 @@ LOGGING = {
     'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
-            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)s %(message)s'
+            'format': ('%(levelname)s %(asctime)s %(module)s %(process)d'
+                       ' %(thread)s %(message)s')
         },
         'simple': {
             'format': '%(asctime)s %(levelname)s %(message)s'

--- a/devday/devday/templates/devday.html
+++ b/devday/devday/templates/devday.html
@@ -13,6 +13,7 @@
 {% endblock content_body %}
 {% endblock %}
 
-{% block content_box_2 %}{% endblock %}
+{% block content_box_2 %}
+{% placeholder "call-to-action" %}
+{% endblock %}
 {% block content_block_2 %}{% endblock %}
-

--- a/devday/devday/templates/devday_no_cta.html
+++ b/devday/devday/templates/devday_no_cta.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% comment %}
+  This is the page template like devday.html, but without the call to action
+  area.
+{% endcomment %}
+{% load cms_tags %}
+
+{% block title %}{% page_attribute "page_title" %}{% endblock title %}
+
+{% block content_block_1 %}
+<div class="stripe c-white">
+    <div class="container">
+        <div class="row ">
+            <div class="col-12 col-lg-9 order-2 order-lg-1{% block content_box_1_wrapper_classes %} col-center{% endblock %} info">
+                <div class="content-center">{% block content_box_1 %}{% placeholder "content" %}{% endblock %}</div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+{% block content_block_2 %}{% endblock %}

--- a/devday/devday/tests/test_utils_devdata.py
+++ b/devday/devday/tests/test_utils_devdata.py
@@ -271,6 +271,14 @@ class DevDataTests(TestCase):
         number_of_tweets = Tweet.objects.count()
         self.assertEquals(number_of_tweets, 7, 'we have 7 tweets')
 
+    def test_get_name_from_email(self):
+        self.assertEquals(
+            self.devdata.get_name_from_email('admin@devday.de'),
+            'admin@devday.de')
+        self.assertEquals(
+            self.devdata.get_name_from_email('first.last@devday.de'),
+            'First Last')
+
     def test_create_devdata(self):
         self.subtest_create_admin_user()
         self.subtest_update_site()

--- a/devday/devday/tests/test_utils_devdata.py
+++ b/devday/devday/tests/test_utils_devdata.py
@@ -95,12 +95,12 @@ class DevDataTests(TestCase):
 
         sponsoring = self.get_page('Sponsoring')
         self.assertEquals(sponsoring.languages, 'de', 'Sponsoring is German')
-        self.assertEquals(sponsoring.template, TEMPLATE_INHERITANCE_MAGIC,
+        self.assertEquals(sponsoring.template, 'devday_no_cta.html',
                           'Sponsoring uses correct template')
 
         impress = self.get_page('Impressum')
         self.assertEquals(impress.languages, 'de', 'Impress is German')
-        self.assertEquals(impress.template, TEMPLATE_INHERITANCE_MAGIC,
+        self.assertEquals(impress.template, 'devday_no_cta.html',
                           'Impress uses correct template')
 
     def subtest_update_static_placeholders(self):

--- a/devday/devday/utils/devdata.py
+++ b/devday/devday/utils/devdata.py
@@ -13,7 +13,6 @@ from shutil import copyfile
 
 import lorem
 from cms import api
-from cms.constants import TEMPLATE_INHERITANCE_MAGIC
 from cms.models import Page
 from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
@@ -27,6 +26,7 @@ from django.core.management.base import OutputWrapper
 from django.core.management.color import no_style
 from django.core.paginator import Paginator
 from django.utils import timezone
+import stringcase
 
 from talk import COMMITTEE_GROUP
 
@@ -135,15 +135,26 @@ class DevData:
             self.write_error()
             raise
 
+    def get_page_title(self, page):
+        return page.get_title_obj_attribute('title', 'de')
+
+    def add_text_plugin_to_placeholder(self, page, slot, body=None):
+        placeholder = page.placeholders.get(slot=slot)
+        if not body:
+            body = "<h1>{} ({})</h1>\n<p>{}</p>\n".format(
+                self.get_page_title(page),
+                stringcase.titlecase(slot),
+                lorem.paragraph())
+        api.add_plugin(placeholder, 'TextPlugin', 'de', body=body)
+
     def create_pages(self):
         index = api.create_page(
             title='Deutsche Homepage', language='de',
             template='devday_index.html',
             parent=None, slug='de', in_navigation=False)
         index.set_as_homepage()
-        eventinfo = index.placeholders.get(slot='eventinfo')
-        api.add_plugin(
-            eventinfo, 'TextPlugin', 'de', body=u'''<h4>Fünf Jahre
+        self.add_text_plugin_to_placeholder(
+            index, 'eventinfo', '''<h4>Fünf Jahre
 DevDay</h4> <p>Der Dev Day feiert seinen fünften Geburtstag - und den wollen
 wir mit euch verbringen! Die <strong>Konferenz</strong> für alle
 <strong>IT-Interessenten</strong> - Studierende oder Professionals, aus Dresden
@@ -159,9 +170,8 @@ zum Wissensaustausch in der T-Systems MMS organisieren wir einmal im Jahr auch
 den Dev Day. Unser größtes Ziel dabei: Wissensaustausch und Vernetzung über die
 Grenzen von Unternehmen und Dresden hinaus.</p>
 ''')
-        cfp_open = index.placeholders.get(slot='cfp_open')
-        api.add_plugin(
-            cfp_open, 'TextPlugin', 'de', body=u'''<h4>Call for Papers</h4>
+        self.add_text_plugin_to_placeholder(
+            index, 'cfp_open', body=u'''<h4>Call for Papers</h4>
 <p>Für den Dev Day 19 brauchen wir wieder eure Unterstützung: meldet euch als
 <strong>Speaker</strong> an und schlagt uns spannende, interessante
 <strong>Vorträge</strong> vor!</p>
@@ -174,27 +184,30 @@ statt eines Abschluss-Vortrags vier weiter, reguläre Talks.</p>
 jeweils bis zu 15 Teilnehmer können zusammen <strong>drei Stunden</strong>
 tiefer in ein Thema einsteigen.</p>
 ''')
-        save_the_date = index.placeholders.get(slot='save_the_date')
-        api.add_plugin(
-            save_the_date, 'TextPlugin', 'de', body=u'''<h4>Save the Date</h4>
+        self.add_text_plugin_to_placeholder(
+            index, 'save_the_date', body=u'''<h4>Save the Date</h4>
 <p>Der Dev Day 19 findet am <strong>21. Mai 2019</strong> am gewohnten Ort, der
 <strong>Börse Dresden</strong> statt.</p>'''
         )
-        sign_up = index.placeholders.get(slot='sign_up')
-        api.add_plugin(
-            sign_up, 'TextPlugin', 'de', body=u'''<h4>Jetzt anmelden</h4>
+        self.add_text_plugin_to_placeholder(
+            index, 'sign_up', body=u'''<h4>Jetzt anmelden</h4>
 <p>Sichert euch jetzt euren kostenfreien Platz auf dem Dev Day!</p>'''
         )
         api.publish_page(index, self.user, 'de')
 
-        api.create_page(
+        sponsoring = api.create_page(
             title='Sponsoring', language='de', published=True,
-            template=TEMPLATE_INHERITANCE_MAGIC,
+            template='devday_no_cta.html',
             reverse_id='sponsoring', parent=None)
-        api.create_page(
+        self.add_text_plugin_to_placeholder(sponsoring, 'content')
+        api.publish_page(sponsoring, self.user, 'de')
+
+        impress = api.create_page(
             title='Impressum', language='de', published=True,
-            template=TEMPLATE_INHERITANCE_MAGIC,
+            template='devday_no_cta.html',
             reverse_id='imprint', parent=None)
+        self.add_text_plugin_to_placeholder(impress, 'content')
+        api.publish_page(impress, self.user, 'de')
 
     def create_static_placeholder_text(self, name, lang='de', paras=3,
                                        title=None, text=None):
@@ -331,7 +344,10 @@ tiefer in ein Thema einsteigen.</p>
 
     def get_name_from_email(self, email):
         m = re.match(r'^([^.]+)\.([^@]+)@.*$', email)
-        return '{} {}'.format(m.group(1).capitalize(), m.group(2).capitalize())
+        if m:
+            return f'{m.group(1).capitalize()} {m.group(2).capitalize()}'
+        else:
+            return email
 
     def create_attendees(self, amount=sys.maxsize, events=None):
         if events is None:  # pragma: no branch


### PR DESCRIPTION
The new template `devday_no_cta.html` leaves out the right-hand block, compared to `devday.html`.

Also:
* translate CMS template entries.
* add a CMS placeholder for the call to action block in devday.html
* make impress and sponsoring test pages use the new template
* add text to all CMS pages
* publish all pages