### PR TITLE
Use vault token role to enable renewable tokens

### DIFF
--- a/docker/vault/Dockerfile
+++ b/docker/vault/Dockerfile
@@ -1,3 +1,3 @@
-FROM vault:0.11.1
+FROM vault:1.0.2
 MAINTAINER Jan Dittberner <jan.dittberner@t-systems.com>
 COPY --chown=vault:vault config /vault/config

--- a/docker/vault/init_unseal_fill_vault.sh
+++ b/docker/vault/init_unseal_fill_vault.sh
@@ -78,6 +78,12 @@ ${CURL} -X PUT --fail --silent -H "X-Vault-Token: ${ROOT_TOKEN}" \
   ${VAULT_API_URL}/sys/policy/devday
 echo "Uploaded policy devday"
 
+# setup token role
+${CURL} -X POST --fail --silent -H "X-Vault-Token: ${ROOT_TOKEN}" \
+  --data '{"allowed_policies": ["devday"]}"' \
+  ${VAULT_API_URL}/auth/token/roles/devday-app
+echo "Setup token role devday-app"
+
 # setup devday item in Vault if it does not exist
 if ${CURL} --silent --fail -H "X-Vault-Token: ${ROOT_TOKEN}" ${VAULT_API_URL}/secret/data/devday >/dev/null; then
   echo "${VAULT_API_URL}/secret/data/devday exists, doing nothing."
@@ -107,7 +113,7 @@ fi
 # create application token
 APP_TOKEN=$(${CURL} -X POST --silent -H "X-Vault-Token: ${ROOT_TOKEN}" \
   --data '{"policies": ["devday"], "metadata": {"user": "devday"}, "ttl": "24h", "renewable": true}' \
-  ${VAULT_API_URL}/auth/token/create | \
+  ${VAULT_API_URL}/auth/token/create/devday-app | \
   python -c 'import json, sys; print json.load(sys.stdin)["auth"]["client_token"]')
 echo "Created application token"
 


### PR DESCRIPTION
Application tokens are only renewable for more than the configured max-ttl if
they are assigned to a token store role. This commit changes the
init_unseal_fill_vault.sh script to create a proper application role and assign
it to newly created application tokens.