### PR TITLE
Renew vault token on application start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ vault-cluster-*.json
 docker/app/vault.crt
 vault-*.json
 /devday/media/
+dev-env

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "15432:5432"
   vault:
-    image: vault:0.11.1
+    image: vault:1.0.2
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: devday_root
       VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
@@ -24,8 +24,9 @@ services:
       - "8000:8000"
     environment:
       VAULT_URL: http://vault:8200
-      VAULT_TOKEN: devday_root
       DJANGO_SETTINGS_MODULE: devday.settings.dev
+    env_file:
+      dev-env
     volumes:
       - "devday_media:/srv/devday/media"
       - "devday_static:/srv/devday/static"

--- a/run.sh
+++ b/run.sh
@@ -10,12 +10,33 @@ DOCKER_COMPOSE="docker-compose -f docker-compose.yml -f docker-compose.dev.yml"
 export DOCKER_REGISTRY="${DOCKER_REGISTRY:-devdaydresden}/"  # note trailing /
 
 docker_compose_up() {
-  $DOCKER_COMPOSE up -d
+  touch dev-env
+  $DOCKER_COMPOSE up -d vault
+  while ! http_proxy= curl --silent --fail http://localhost:8200/v1/sys/health; do
+    echo -n '.'
+  done
+  echo " vault is running"
   # fill vault with content
   http_proxy= \
-      curl -X POST -H "X-Vault-Token: devday_root" \
+      curl -X POST -H "X-Vault-Token: devday_root" --fail \
       --data '{"data": {"postgresql_password": "devday", "secret_key": "s3cr3t"}}' \
       http://localhost:8200/v1/secret/data/devday
+  http_proxy= \
+      curl -X PUT -H "X-Vault-Token: devday_root" --fail \
+      --data "$(printf '{"policy": "%s"}' \
+      "$(sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\n/g' -e 's/"/\\"/g' < docker/vault/devday_policy.hcl)")" \
+      http://localhost:8200/v1/sys/policy/devday
+  http_proxy= \
+      curl -X POST -H "X-Vault-Token: devday_root" --fail \
+      --data '{"allowed_policies": ["devday"]}"' \
+      http://localhost:8200/v1/auth/token/roles/devday-app
+  http_proxy= \
+      APP_TOKEN=$(curl -X POST --silent -H "X-Vault-Token: devday_root" --fail \
+      --data '{"policies": ["devday"], "metadata": {"user": "devday"}, "ttl": "24h", "renewable": true}' \
+      http://localhost:8200/v1/auth/token/create/devday-app | \
+      python -c 'import json, sys; print json.load(sys.stdin)["auth"]["client_token"]')
+  echo "VAULT_TOKEN=${APP_TOKEN}" > dev-env
+  $DOCKER_COMPOSE up -d
 }
 
 usage() {

--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,6 @@ DOCKER_COMPOSE="docker-compose -f docker-compose.yml -f docker-compose.dev.yml"
 export DOCKER_REGISTRY="${DOCKER_REGISTRY:-devdaydresden}/"  # note trailing /
 
 docker_compose_up() {
-  touch dev-env
   $DOCKER_COMPOSE up -d vault
   while ! http_proxy= curl --silent --fail http://localhost:8200/v1/sys/health; do
     echo -n '.'
@@ -86,6 +85,8 @@ shift $((OPTIND-1))
 
 cmd="$1"
 shift || true
+
+touch dev-env
 
 case "$cmd" in
   backup)


### PR DESCRIPTION
This commit makes sure that the Vault application token is renewed when the application is started. This is especially useful with periodically scheduled tasks like fetching tweets and avoids a separate job to renew the token from outside of the application container.