### PR TITLE
Travis python 3 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: true
+python: 3.6
 services:
 - docker
 notifications:


### PR DESCRIPTION
Travis CI does not report coverage for all our files because coveralls is run with Python 2. This PR configures the Travis CI build to use Python 3.6. Coverage will most probably decrease.