### PR TITLE
Disable the sponsoring link only

### DIFF
--- a/devday/devday/templates/base.html
+++ b/devday/devday/templates/base.html
@@ -75,28 +75,28 @@
     {% endblock content_block_2 %}
 
     {% block content_block_3 %}
-    {% if sponsoring_open or has_change_permissions %}
     <div class="stripe c-gray{% if not sponsoring_open %} visible-to-editor-only{% endif %}">
         <div class="container">
             <div class="row ">
                 <div class="col-12 col-lg-9 order-2 order-lg-1">
-                    <div class="row sponsor">{% static_placeholder "sponsors" %}</div>
+                    <div class="row sponsor">{% static_placeholder "sponsors" or %}{% trans "Thanks to our sponsors" %}{% endstatic_placeholder %}</div>
                 </div>
                 {% block content_block_sponsoring_link %}
-                {% page_url 'sponsoring' as sponsoring_page %}
                 <div class="col-12 col-lg-3  order-1 order-lg-2 col-center col-base">
+                    {% if sponsoring_open or has_change_permissions %}
+                    {% page_url 'sponsoring' as sponsoring_page %}
                     <div class="content-center">
                         {% if request.path != sponsoring_page %}
                         <p>Wollen Sie Sponsoringpartner werden? Schauen Sie sich unsere Sponsoring Optionen an.</p>
                         <a href="{{ sponsoring_page }}" class="btn btn-outline btn-call-action m-t-1">Jetzt Sponsor werden</a>
                         {% endif %}
                     </div>
+                    {% endif %}
                 </div>
                 {% endblock content_block_sponsoring_link %}
             </div>
         </div>
     </div>
-    {% endif %}
     {% endblock %}
 
     <footer>


### PR DESCRIPTION
The SPONSORING_OPEN setting should not influence the display of the sponsor
block. This commit changes the behaviour accordingly.