### PR TITLE
Handle closed attendee registration

### DIFF
--- a/devday/attendee/templates/attendee/profile.html
+++ b/devday/attendee/templates/attendee/profile.html
@@ -56,7 +56,7 @@
                                         {% if not user.get_speaker %}
                                         <div class="btn-group float-left float-sm-right">
                                             <a class="btn btn-primary"
-                                                  href="{% url "attendee_cancel" event=event.id %}">{% trans "Cancel Registration" %}</a>
+                                                  href="{% url "attendee_cancel" event=event.slug %}">{% trans "Cancel Registration" %}</a>
                                         </div>
                                         {% endif %}
                                         {% addtoblock "js" %}


### PR DESCRIPTION
This PR adds a new AttendeeRequiredMixin and changes existing views
in the attendee and talk apps to use this mixin. The mixin makes sure
that views that require an attendee redirect to the attendee
registration view as long as the event allows attendee registration. If
the attendee registration is closed the mixin redirects to the
django_registration_disallowed url.

The PR also ensures that knowing the attendee registration URL is
not sufficient to register an attendee and that no attendee activation
is possible when the attendee registration has been closed.

All tests have been adapted, new tests have been added.

This fixes #160