### PR TITLE
Add path for twitterwall to reverse proxy

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -57,8 +57,10 @@ services:
     volumes:
       - "devday_media:/usr/local/apache2/htdocs/media"
       - "devday_static:/usr/local/apache2/htdocs/static"
+      - "devday_twitterwall:/usr/local/apache2/htdocs/twitterwall"
 
 volumes:
   vaultlogs:
   vaultfile:
   devday_logs:
+  devday_twitterwall:

--- a/docker/revproxy/httpd.conf
+++ b/docker/revproxy/httpd.conf
@@ -231,9 +231,11 @@ DocumentRoot "/usr/local/apache2/htdocs"
 
     Alias /static/ /usr/local/apache2/htdocs/static/
     Alias /media/ /usr/local/apache2/htdocs/media/
+    Alias /app-twitterwall/ /usr/local/apache2/htdocs/twitterwall/
 
     ProxyPass "/static/" "!"
     ProxyPass "/media/" "!"
+    ProxyPass "/app-twitterwall/" "!"
 
     ProxyPreserveHost on
     ProxyPass / http://app:7000/


### PR DESCRIPTION
This PR prepares the Apache reverse proxy to serve https://github.com/devdaydresden/devday_twitterwall from /app-twitterwall/ from a separate docker volume