### PR TITLE
Disable session reservation when event starts

### DIFF
--- a/devday/attendee/templates/attendee/profile.html
+++ b/devday/attendee/templates/attendee/profile.html
@@ -32,19 +32,23 @@
                                         {% for reservation in reservations %}
                                             {% with talk=reservation.talk %}
                                             <div class="list-group-item">
-                                                <p><a href="{% url 'talk_details' event=talk.event.slug slug=talk.slug as talk_details %}">{{ talk.title }}</a></p>
-                                                <p>
-                                                {% if reservation.is_confirmed %}
-                                                    <span class="fas fa-check-circle text-success" title="{% trans "You are a confirmed attendee of this session" %}" aria-label="{% trans "You are a confirmed attendee of this session" %}"></span>
-                                                    <a href="{% url "talk_cancel_reservation" event=talk.event.slug slug=talk.slug %}"><span class="fas fa-calendar-times"></span> {% trans "Cancel reservation" %}</a>
-                                                {% elif reservation.is_waiting %}
-                                                    <span class="fas fa-question-circle text-danger" title="{% trans "You are on a waiting list for this session" %}" aria-label="{% trans "You are on a waiting list for this session" %}"></span>
-                                                    <a href="{% url "talk_cancel_reservation" event=talk.event.slug slug=talk.slug %}"><span class="fas fa-calendar-times"></span> {% trans "Remove from waiting list" %}</a>
-                                                {% else %}
-                                                    <span class="fas fa-question-circle text-warning" title="{% trans "You have not confirmed your reservation for this session" %}" aria-label="{% trans "You have not confirmed your reservation for this session" %}"></span>
-                                                    <a href="{% url "talk_resend_confirmation" event=talk.event.slug slug=talk.slug %}"><span class="fas fa-send"></span> {% trans "Resend confirmation mail" %}</a>
+                                                {% if talk.is_reservation_available %}
+                                                    <p><a href="{% url 'talk_details' event=talk.event.slug slug=talk.slug as talk_details %}">{{ talk.title }}</a></p>
+                                                    <p>
+                                                    {% if reservation.is_confirmed %}
+                                                        <span class="fas fa-check-circle text-success" title="{% trans "You are a confirmed attendee of this session" %}" aria-label="{% trans "You are a confirmed attendee of this session" %}"></span>
+                                                        <a href="{% url "talk_cancel_reservation" event=talk.event.slug slug=talk.slug %}"><span class="fas fa-calendar-times"></span> {% trans "Cancel reservation" %}</a>
+                                                    {% elif reservation.is_waiting %}
+                                                        <span class="fas fa-question-circle text-danger" title="{% trans "You are on a waiting list for this session" %}" aria-label="{% trans "You are on a waiting list for this session" %}"></span>
+                                                        <a href="{% url "talk_cancel_reservation" event=talk.event.slug slug=talk.slug %}"><span class="fas fa-calendar-times"></span> {% trans "Remove from waiting list" %}</a>
+                                                    {% else %}
+                                                        <span class="fas fa-question-circle text-warning" title="{% trans "You have not confirmed your reservation for this session" %}" aria-label="{% trans "You have not confirmed your reservation for this session" %}"></span>
+                                                        <a href="{% url "talk_resend_confirmation" event=talk.event.slug slug=talk.slug %}"><span class="fas fa-send"></span> {% trans "Resend confirmation mail" %}</a>
+                                                    {% endif %}
+                                                    </p>
+                                                {% elif reservation.is_confirmed %}
+                                                    <p><a href="{% url 'talk_details' event=talk.event.slug slug=talk.slug as talk_details %}">{{ talk.title }}</a></p>
                                                 {% endif %}
-                                                </p>
                                             </div>
                                             {% endwith %}
                                         {% endfor %}
@@ -52,7 +56,7 @@
                                     {% endif %}
                                 </td>
                                 <td>
-                                    {% if event.id == current_event.id %}
+                                    {% if event.is_raffle_available %}
                                         <div class="form-check-inline">
                                             <input class="form-check-input" type="checkbox" {% if attendee.raffle %}checked{% endif %} id="raffle-checkbox" data-toggle-url="{% url "attendee_toggle_raffle" event=event.slug %}">
                                             <label class="form-check-label">{% trans "Take part in the raffle" %}</label>

--- a/devday/devday/templates/devday_index.html
+++ b/devday/devday/templates/devday_index.html
@@ -20,7 +20,7 @@
 {% endif %}
 {% if sessions_published or has_change_permissions %}
     {% if reservable_sessions or has_change_permissions %}
-        <div class="{% if not sessions_published %}visible-to-editor-only{% endif %}">
+        <div class="{% if not reservable_sessions %}visible-to-editor-only{% endif %}">
         {% placeholder "reserve_spot" or %}{% trans "Reserve your spot in one of the workshops or the excursion." %}{% endplaceholder %}
         <p><a class="btn btn-outline btn-call-action m-t-1"
               href="{% url 'limited_talk_reservation' event=current_event.slug %}"

--- a/devday/event/models.py
+++ b/devday/event/models.py
@@ -93,6 +93,12 @@ class Event(models.Model):
     def is_started(self):
         return self.start_time < timezone.now()
 
+    def is_running(self):
+        return self.start_time < timezone.now() < self.end_time
+
+    def has_ended(self):
+        return self.end_time < timezone.now()
+
     def get_absolute_url(self):
         return reverse("session_list", kwargs={"event": self.slug})
 

--- a/devday/event/models.py
+++ b/devday/event/models.py
@@ -99,6 +99,9 @@ class Event(models.Model):
     def has_ended(self):
         return self.end_time < timezone.now()
 
+    def is_raffle_available(self):
+        return not self.has_ended()
+
     def get_absolute_url(self):
         return reverse("session_list", kwargs={"event": self.slug})
 

--- a/devday/event/tests/test_models.py
+++ b/devday/event/tests/test_models.py
@@ -120,3 +120,51 @@ class EventTest(TestCase):
             end_time=now + timedelta(hours=1)
         )
         self.assertTrue(event.is_started())
+
+    def test_is_running(self):
+        now = timezone.now()
+        event = Event(
+            title="Test running",
+            description="Test Event running",
+            start_time=now - timedelta(hours=1),
+            end_time=now + timedelta(hours=1)
+        )
+        self.assertTrue(event.is_running())
+        event = Event(
+            title="Test future",
+            description="Test Event not running yet",
+            start_time=now + timedelta(hours=1),
+            end_time=now + timedelta(hours=2)
+        )
+        self.assertFalse(event.is_running())
+        event = Event(
+            title="Test past",
+            description="Test Event not running anymore",
+            start_time=now - timedelta(hours=2),
+            end_time=now - timedelta(hours=1)
+        )
+        self.assertFalse(event.is_running())
+
+    def test_has_ended(self):
+        now = timezone.now()
+        event = Event(
+            title="Test running",
+            description="Test Event running",
+            start_time=now - timedelta(hours=1),
+            end_time=now + timedelta(hours=1)
+        )
+        self.assertFalse(event.has_ended())
+        event = Event(
+            title="Test future",
+            description="Test Event in the future",
+            start_time=now + timedelta(hours=1),
+            end_time=now + timedelta(hours=2)
+        )
+        self.assertFalse(event.has_ended())
+        event = Event(
+            title="Test past",
+            description="Test Event that has ended",
+            start_time=now - timedelta(hours=2),
+            end_time=now - timedelta(hours=1),
+        )
+        self.assertTrue(event.has_ended())

--- a/devday/talk/context_processors.py
+++ b/devday/talk/context_processors.py
@@ -15,7 +15,7 @@ def committee_member_context_processor(request):
 
 def reservation_context_processor(request):
     event = Event.objects.current_event()
-    if event.sessions_published:
+    if event.sessions_published and not event.is_started():
         return {
             "reservable_sessions": Talk.objects.filter(
                 event=event, track__isnull=False, spots__gt=0

--- a/devday/talk/templates/talk/talk_details.html
+++ b/devday/talk/templates/talk/talk_details.html
@@ -19,7 +19,7 @@
             {% endif %}
             <p>{{ talk.abstract|linebreaksbr }}</p>
             {% if current %}
-                {% if talk.spots %}
+                {% if talk.is_reservation_available %}
                     <p><span class="talk-actions">
                         {% if reservation %}
                             {% if reservation.is_confirmed %}

--- a/devday/talk/templates/talk/talk_grid_entry.html
+++ b/devday/talk/templates/talk/talk_grid_entry.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <span class="talk-entry">
-    {% if talk.spots %}
+    {% if talk.is_reservation_available %}
         <a href="{% url "talk_reservation" event=talk.event.slug slug=talk.slug %}" class="btn btn-primary"><span class="talk-icons"><span class="fas fa-calendar-check float-left mt-1 mr-1"></span>{% trans "Needs reservation" %}</span></a>
     {% endif %}
     <span class="title"><a

--- a/devday/talk/tests/test_context_processors.py
+++ b/devday/talk/tests/test_context_processors.py
@@ -1,6 +1,9 @@
+from datetime import timedelta
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.test import TestCase
+from django.utils import timezone
 
 from attendee.models import Attendee
 from attendee.tests import attendee_testutils
@@ -65,6 +68,8 @@ class TestReservationContextProcessor(TestCase):
 
     def test_reservable_sessions_true_if_talks_with_spots(self):
         self.event.sessions_published = True
+        self.event.start_time = timezone.now() + timedelta(hours=1)
+        self.event.end_time = timezone.now() + timedelta(hours=2)
         self.event.save()
         speaker, _, _ = speaker_testutils.create_test_speaker()
         talk = talk_testutils.create_test_talk(

--- a/devday/talk/tests/test_views.py
+++ b/devday/talk/tests/test_views.py
@@ -1400,8 +1400,13 @@ class TestAttendeeTalkClearVote(TestCase):
 
 class TestTalkAddReservation(TestCase):
     def setUp(self):
+        now = timezone.now()
         self.event = event_testutils.create_test_event(
-            "test event", published=True, sessions_published=True
+            "test event",
+            published=True,
+            sessions_published=True,
+            start_time=now + timedelta(hours=1),
+            end_time=now + timedelta(hours=2),
         )
         speaker, _, _ = speaker_testutils.create_test_speaker()
         self.talk = talk_testutils.create_test_talk(
@@ -1889,8 +1894,13 @@ class TestTalkReservationWaiting(TestCase):
 
 class TestLimitedTalkList(TestCase):
     def setUp(self):
+        now = timezone.now()
         self.event = event_testutils.create_test_event(
-            "test event", published=True, sessions_published=True
+            "test event",
+            published=True,
+            sessions_published=True,
+            start_time=now + timedelta(hours=1),
+            end_time=now + timedelta(hours=2),
         )
         speaker1, _, _ = speaker_testutils.create_test_speaker()
         speaker2, _, _ = speaker_testutils.create_test_speaker(
@@ -2096,28 +2106,40 @@ class TestTalkFeedbackSummaryView(TestCase):
         )
         self.speakers = [
             PublishedSpeaker.objects.create(
-                name="Speaker 1", event=self.event, video_permission=True,
+                name="Speaker 1",
+                event=self.event,
+                video_permission=True,
                 email="testspeaker1@example.org",
             ),
             PublishedSpeaker.objects.create(
-                name="Speaker 2", event=self.event, video_permission=True,
-                email = "testspeaker2@example.org",
+                name="Speaker 2",
+                event=self.event,
+                video_permission=True,
+                email="testspeaker2@example.org",
             ),
             PublishedSpeaker.objects.create(
-                name="Speaker 3", event=self.event, video_permission=True,
-                email = "testspeaker3@example.org",
+                name="Speaker 3",
+                event=self.event,
+                video_permission=True,
+                email="testspeaker3@example.org",
             ),
             PublishedSpeaker.objects.create(
-                name="Speaker 4", event=self.event, video_permission=True,
-                email = "testspeaker4@example.org",
+                name="Speaker 4",
+                event=self.event,
+                video_permission=True,
+                email="testspeaker4@example.org",
             ),
             PublishedSpeaker.objects.create(
-                name="Speaker 5", event=self.event, video_permission=True,
-                email = "testspeaker5@example.org",
+                name="Speaker 5",
+                event=self.event,
+                video_permission=True,
+                email="testspeaker5@example.org",
             ),
             PublishedSpeaker.objects.create(
-                name="Speaker 6", event=self.event, video_permission=True,
-                email = "testspeaker6@example.org",
+                name="Speaker 6",
+                event=self.event,
+                video_permission=True,
+                email="testspeaker6@example.org",
             ),
         ]
         track = Track.objects.create(name="Test Track")

--- a/devday/talk/views.py
+++ b/devday/talk/views.py
@@ -1068,7 +1068,7 @@ class TalkAddReservation(
 
     def get_talk_and_attendee(self, **kwargs):
         self.talk = get_object_or_404(
-            Talk, event=self.event, slug=kwargs["slug"], spots__gt=0
+            Talk, event=self.event, event__start_time__gt=timezone.now(), slug=kwargs["slug"], spots__gt=0
         )
 
     def get_context_data(self, **kwargs):
@@ -1293,8 +1293,8 @@ class LimitedTalkList(ListView):
             queryset=SessionReservation.objects.filter(is_confirmed=True),
         )
         return (
-            Talk.objects.filter(
-                event__slug=self.kwargs.get("event"), track__isnull=False, spots__gt=0
+            Talk.reservable.filter(
+                event__slug=self.kwargs.get("event"), track__isnull=False
             )
                 .prefetch_related(confirmed_reservations)
                 .order_by("title")


### PR DESCRIPTION
The PR disables the session reservation when an event starts. Links to the corresponding views are not rendered and the views for showing limited sessions are disabled by a custom model manager on the Talk model.