### PR TITLE
Update to Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: true
-python: 3.6
+python: 3.7
 services:
 - docker
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 sudo: true
 python: 3.7

--- a/docker/app/Dockerfile-dev
+++ b/docker/app/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.7-alpine
 MAINTAINER Jan Dittberner <jan.dittberner@t-systems.com>
 LABEL vendor="T-Systems Multimedia Solutions GmbH"
 LABEL devday.release=0.1

--- a/docker/app/Dockerfile-prod
+++ b/docker/app/Dockerfile-prod
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.7-alpine
 MAINTAINER Jan Dittberner <jan.dittberner@t-systems.com>
 LABEL vendor="T-Systems Multimedia Solutions GmbH"
 LABEL devday.release=0.1


### PR DESCRIPTION
alpine:3.10 brings uwsgi-python3 linked against Python 3.7.3. python:3.6-alpine is based on alpine:3.10 and is broken when used with uwsgi-python3 because of this change.

This PR switches our base image to Python 3.7 and restores uwsgi-python3 functionality.