### PR TITLE
Allow 0.0.0.0 to Access Page in Development

### DIFF
--- a/devday/devday/settings/base.py
+++ b/devday/devday/settings/base.py
@@ -113,7 +113,9 @@ mimetypes.add_type("image/svg+xml", ".svg", True)
 # settings for django-django_registration
 # see: https://django-registration.readthedocs.io/en/2.1.1/index.html
 ACCOUNT_ACTIVATION_DAYS = 14
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    "0.0.0.0"
+]
 AUTH_USER_MODEL = "attendee.DevDayUser"
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/devday/devday/settings/base.py
+++ b/devday/devday/settings/base.py
@@ -113,9 +113,7 @@ mimetypes.add_type("image/svg+xml", ".svg", True)
 # settings for django-django_registration
 # see: https://django-registration.readthedocs.io/en/2.1.1/index.html
 ACCOUNT_ACTIVATION_DAYS = 14
-ALLOWED_HOSTS = [
-    "0.0.0.0"
-]
+ALLOWED_HOSTS = []
 AUTH_USER_MODEL = "attendee.DevDayUser"
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/devday/devday/settings/dev.py
+++ b/devday/devday/settings/dev.py
@@ -35,3 +35,9 @@ TWITTERFEED_PROXIES = {
     'http': '',
     'https': '',
 }
+
+ALLOWED_HOSTS = [
+    "0.0.0.0",
+    "127.0.0.1",
+    "localhost"
+]


### PR DESCRIPTION
The Docker container starts the Django application by binding
it on 0.0.0.0. This is required to allow accessing the application
from "outside" of the container (aka the developers computer).

The Docker container will print a message that tells the
developer that the app is available at "http://0.0.0.0:8000".

Unfortunately, this is "IP" is not a "allowed host" out-of-the-box.
Therefore, this "IP" has to be added to the "ALLOWED_HOSTS" array
in the configuration.

With this change you can click on the link that Djangos
"./manage.py runserver 0.0.0.0:8000" prints and access the page.