### PR TITLE
Fix AttributeError on speaker profile page

### DIFF
--- a/devday/speaker/tests/test_views.py
+++ b/devday/speaker/tests/test_views.py
@@ -8,7 +8,7 @@ from speaker.forms import CreateSpeakerForm, UserSpeakerPortraitForm
 from speaker.models import PublishedSpeaker, Speaker
 from speaker.tests import speaker_testutils
 from speaker.tests.speaker_testutils import TemporaryMediaTestCase
-from talk.models import Talk, Track, TalkPublishedSpeaker
+from talk.models import Talk, TalkPublishedSpeaker, Track
 
 
 class TestCreateSpeakerView(TestCase):
@@ -109,6 +109,22 @@ class TestUserSpeakerProfileView(TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["speaker"], self.speaker)
+
+    def test_talk_on_speaker_profile(self):
+        event = event_testutils.create_test_event()
+        talk = Talk.objects.create(
+            draft_speaker=self.speaker,
+            title="Test Talk",
+            abstract="Test abstract",
+            remarks="",
+            event=event,
+        )
+        self.client.login(username=self.email, password=self.password)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["speaker"], self.speaker)
+        self.assertIn("sessions", response.context)
+        self.assertIn(talk, response.context["sessions"])
 
 
 class TestUserSpeakerPortraitUploadView(TemporaryMediaTestCase):

--- a/devday/speaker/views.py
+++ b/devday/speaker/views.py
@@ -67,7 +67,7 @@ class UserSpeakerProfileView(LoginRequiredMixin, UpdateView):
                 ).order_by("start_time"),
                 "sessions": Talk.objects.filter(draft_speakers=context["speaker"])
                 .select_related("event")
-                .prefetch_related("draft_speaker", "published_speaker")
+                .prefetch_related("draft_speakers", "published_speakers")
                 .order_by("-event__title", "title"),
                 "speaker_image_height": settings.TALK_PUBLIC_SPEAKER_IMAGE_HEIGHT,
                 "speaker_image_width": settings.TALK_PUBLIC_SPEAKER_IMAGE_WIDTH,


### PR DESCRIPTION
The changes in #255 introduced a regression on the speaker profile page
(AttributeError in prefetch_related) that is fixed by this commit. A
test to reproduce the error is included.

addresses #251