### PR TITLE
Only Show QR Code for Login for Offline Events

### DIFF
--- a/devday/devday/cms_menus.py
+++ b/devday/devday/cms_menus.py
@@ -148,6 +148,7 @@ class DevDayModifier(Modifier):
         return (
             request.user.is_authenticated
             and event.published
+            and not event.online_event
             and request.user.get_attendee(event) is not None
         )
 


### PR DESCRIPTION
After the introduction of online events the QR code that we use for
onsite registration is not necessary.

Closes: #257