### PR TITLE
Use the correct variable for the speaker name

### DIFF
--- a/devday/talk/templates/talk/talk_grid_entry.html
+++ b/devday/talk/templates/talk/talk_grid_entry.html
@@ -6,5 +6,5 @@
     <span class="title"><a
             href="{% url 'talk_details' event=talk.event.slug slug=talk.slug %}">{{ talk.title }}</a></span>
     <span class="speaker">{% for speaker in talk.published_speakers.all %}<a
-            href="{% url 'public_speaker_profile' event=talk.event.slug slug=speaker.slug %}">{{ talk.speaker.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</span>
+            href="{% url 'public_speaker_profile' event=talk.event.slug slug=speaker.slug %}">{{ speaker.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</span>
 </span>


### PR DESCRIPTION
This PR fixes the speaker links in the session grid