### PR TITLE
Link to slides and videos instead of embedding

### DIFF
--- a/devday/devday/utils/devdata.py
+++ b/devday/devday/utils/devdata.py
@@ -525,11 +525,11 @@ wir unterstützen gern. Denn wir freuen uns über vielfältige Einreichungen!</p
             talk.media.talk = talk
 
             if self.rng.randint(0, 2) > 0:
-                talk.media.youtube = "E5VN-MI1mZA"
+                talk.media.video = "https://www.youtube.com/watch?v=E5VN-MI1mZA"
             if self.rng.randint(0, 2) > 0:
-                talk.media.slideshare = "zEvpGJkZqrLIGa"
+                talk.media.slides = "https://www.slideshare.net/CBInsights/global-healthcare-report-q2-2019-162433349?ref="
             if self.rng.randint(0, 2) > 0:
-                talk.media.codelink = "https://github.com/devdaydresden/devday_website"
+                talk.media.code = "https://github.com/devdaydresden/devday_website"
             talk.media.save()
 
     def vote_for_talk(self, events=None):

--- a/devday/talk/locale/de/LC_MESSAGES/django.po
+++ b/devday/talk/locale/de/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: devday talk app\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-26 17:06+0000\n"
-"PO-Revision-Date: 2020-02-11 20:45+0100\n"
+"POT-Creation-Date: 2020-07-09 13:57+0000\n"
+"PO-Revision-Date: 2020-07-09 16:00+0200\n"
 "Last-Translator: Jan Dittberner <jan.dittberner@t-systems.com>\n"
 "Language-Team: Jan Dittberner <jan.dittberner@t-systems.com>\n"
 "Language: de\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 2.2.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #: talk/admin.py:125
@@ -49,8 +49,8 @@ msgstr "Warteliste für ausgewählte Sessions verarbeiten"
 msgid "Talk slot created successfully"
 msgstr "Talk-Slot erfolgreich angelegt"
 
-#: talk/admin.py:254 talk/models.py:29 talk/models.py:83 talk/models.py:327
-#: talk/models.py:348
+#: talk/admin.py:254 talk/models.py:29 talk/models.py:83 talk/models.py:321
+#: talk/models.py:342
 msgid "Event"
 msgstr "Veranstaltung"
 
@@ -122,8 +122,8 @@ msgstr "Session"
 msgid "Sessions"
 msgstr "Sessions"
 
-#: talk/models.py:163 talk/models.py:175 talk/models.py:400 talk/models.py:430
-#: talk/models.py:464 talk/templates/talk/talk_committee_details.html:3
+#: talk/models.py:163 talk/models.py:175 talk/models.py:394 talk/models.py:424
+#: talk/models.py:458 talk/templates/talk/talk_committee_details.html:3
 #: talk/templates/talk/talk_details.html:3
 msgid "Talk"
 msgstr "Session"
@@ -146,11 +146,11 @@ msgstr "Veröffentlichte SpeakerInnen"
 
 #: talk/models.py:184
 msgid "Talk published speaker"
-msgstr ""
+msgstr "Veröffentlichte/r SpeakerIn"
 
 #: talk/models.py:185
 msgid "Talk published speakers"
-msgstr ""
+msgstr "Veröffentlichte/r SpeakerInnen"
 
 #: talk/models.py:213 talk/models.py:225
 msgid "Cannot delete last draft speaker from talk without published speaker"
@@ -162,108 +162,110 @@ msgid "Cannot delete last published speaker from talk without draft speaker"
 msgstr ""
 "Ein/e SpeakerIn (öffentlich) oder SpeakerIn (Entwurf) ist erforderlich."
 
+#: talk/models.py:269 talk/templates/talk/talk_details.html:41
+#: talk/templates/talk/talk_list_entry.html:22
+#: talk/templates/talk/talk_videos.html:26
+msgid "Video"
+msgstr "Video"
+
 #: talk/models.py:270
-msgid "Youtube video id"
-msgstr "Youtube-Video-ID"
+msgid "Slides"
+msgstr "Folien"
 
-#: talk/models.py:273
-msgid "Slideshare id"
-msgstr "Slideshare-ID"
-
-#: talk/models.py:276
+#: talk/models.py:271
 msgid "Source code"
 msgstr "Quellcode"
 
-#: talk/models.py:300 talk/models.py:470
+#: talk/models.py:294 talk/models.py:464
 msgid "Comment"
 msgstr "Kommentar"
 
-#: talk/models.py:302
+#: talk/models.py:296
 msgid "Visible for Speaker"
 msgstr "Sichtbar für den/die SpeakerIn"
 
-#: talk/models.py:304
+#: talk/models.py:298
 msgid "Indicates whether the comment is visible to the speaker."
 msgstr "Gibt an, ob der Kommentar für den/die SpeakerIn sichtbar ist."
 
-#: talk/models.py:324 talk/templates/talk/speaker_details.html:11
+#: talk/models.py:318 talk/templates/talk/speaker_details.html:11
 msgid "Name"
 msgstr "Name"
 
-#: talk/models.py:325
+#: talk/models.py:319
 msgid "Priority"
 msgstr "Priorität"
 
-#: talk/models.py:333
+#: talk/models.py:327
 msgid "Room"
 msgstr "Raum"
 
-#: talk/models.py:334
+#: talk/models.py:328
 msgid "Rooms"
 msgstr "Räume"
 
-#: talk/models.py:350
+#: talk/models.py:344
 msgid "Block"
 msgstr "Block"
 
-#: talk/models.py:353
+#: talk/models.py:347
 msgid "Time slot"
 msgstr "Zeitslot"
 
-#: talk/models.py:354
+#: talk/models.py:348
 msgid "Time slots"
 msgstr "Zeitslots"
 
-#: talk/models.py:368
+#: talk/models.py:362
 msgid "Talk slot"
 msgstr "Session-Slot"
 
-#: talk/models.py:369
+#: talk/models.py:363
 msgid "Talk slots"
 msgstr "Session-Slots"
 
-#: talk/models.py:377
+#: talk/models.py:371
 msgid "Duration"
 msgstr "Länge"
 
-#: talk/models.py:382 talk/models.py:383
+#: talk/models.py:376 talk/models.py:377
 msgid "Talk Format"
 msgstr "Session-Format"
 
-#: talk/models.py:393 talk/models.py:423 talk/models.py:456
+#: talk/models.py:387 talk/models.py:417 talk/models.py:450
 msgid "Attendee"
 msgstr "Teilnehmer"
 
-#: talk/models.py:405
+#: talk/models.py:399
 msgid "Confirmed"
 msgstr "Bestätigt"
 
-#: talk/models.py:406
+#: talk/models.py:400
 msgid "On waiting list"
 msgstr "Auf der Warteliste"
 
-#: talk/models.py:409
+#: talk/models.py:403
 msgid "Session reservation"
 msgstr "Platzreservierung"
 
-#: talk/models.py:410
+#: talk/models.py:404
 msgid "Session reservations"
 msgstr "Platzreservierungen"
 
-#: talk/models.py:440
+#: talk/models.py:434
 msgid "Attendee vote"
 msgstr "Teilnehmerabstimmung"
 
-#: talk/models.py:441
+#: talk/models.py:435
 msgid "Attendee votes"
 msgstr "Teilnehmerabstimmungen"
 
-#: talk/models.py:474
+#: talk/models.py:468
 msgctxt "attendee feedback singular form"
 msgid "Attendee feedback"
 msgstr "Teilnehmerfeedback"
 
-#: talk/models.py:477
+#: talk/models.py:471
 msgctxt "attendee feedback plural form"
 msgid "Attendee feedback"
 msgstr "Teilnehmerfeedback"
@@ -865,20 +867,18 @@ msgstr[1] "(Insgesamt %(vote_sum)s bei %(vote_count)s Stimmen)"
 msgid "There are no talks yet."
 msgstr "Es wurden noch keine Sessions eingereicht."
 
-#: talk/templates/talk/talk_details.html:41
-msgid "Video"
-msgstr "Video"
-
-#: talk/templates/talk/talk_details.html:54
+#: talk/templates/talk/talk_details.html:51
+#: talk/templates/talk/talk_videos.html:31
 msgid "Slide deck"
 msgstr "Folien"
 
-#: talk/templates/talk/talk_details.html:68
-#: talk/templates/talk/talk_videos.html:41
+#: talk/templates/talk/talk_details.html:61
+#: talk/templates/talk/talk_list_entry.html:24
+#: talk/templates/talk/talk_videos.html:36
 msgid "Example code"
 msgstr "Beispielcode"
 
-#: talk/templates/talk/talk_details.html:76
+#: talk/templates/talk/talk_details.html:69
 msgid "Your feedback for this session"
 msgstr "Dein Feedback für diese Session"
 
@@ -963,6 +963,10 @@ msgstr "Aus der Warteliste entfernen"
 msgid "Archive: List of Talks at"
 msgstr "Archiv: Liste der Vorträge vom"
 
+#: talk/templates/talk/talk_list_entry.html:23
+msgid "Slide Deck"
+msgstr "Folien"
+
 #: talk/templates/talk/talk_list_preview.html:7
 msgid "Schedule Preview"
 msgstr "Sessionvorschau"
@@ -986,11 +990,11 @@ msgstr "%(event.title)s - Videos, Folien und Beispielcode"
 msgid "Videos, Slides and Example Code for %(event.title)s"
 msgstr "Videos, Folien und Beispielcode für %(event.title)s"
 
-#: talk/templates/talk/talk_videos.html:51
+#: talk/templates/talk/talk_videos.html:46
 msgid "No videos, slides or example code found."
 msgstr "Keine Videos, Folien oder Beispielcode gefunden."
 
-#: talk/templates/talk/talk_videos.html:53
+#: talk/templates/talk/talk_videos.html:48
 #, python-format
 msgid "Videos and Slides for %(event)s have not been published yet."
 msgstr "Es wurden noch keine Videos und Folien für %(event)s veröffentlicht."

--- a/devday/talk/migrations/0045_use_links_for_talk_media_add_new_fields.py
+++ b/devday/talk/migrations/0045_use_links_for_talk_media_add_new_fields.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('talk', '0044_auto_20200310_2010'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='talkmedia',
+            name='code',
+            field=models.URLField(blank=True, verbose_name='Source code'),
+        ),
+        migrations.AddField(
+            model_name='talkmedia',
+            name='slides',
+            field=models.URLField(blank=True, verbose_name='Slides'),
+        ),
+        migrations.AddField(
+            model_name='talkmedia',
+            name='video',
+            field=models.URLField(blank=True, verbose_name='Video'),
+        ),
+    ]

--- a/devday/talk/migrations/0046_use_links_for_talk_media_migrate_content.py
+++ b/devday/talk/migrations/0046_use_links_for_talk_media_migrate_content.py
@@ -1,0 +1,50 @@
+import requests
+from bs4 import BeautifulSoup
+from django.db import migrations, models
+
+
+def migrate_code_links(apps, schema_editor):
+    TalkMedia = apps.get_model("talk", "TalkMedia")
+
+    db_alias = schema_editor.connection.alias
+    for media in TalkMedia.objects.using(db_alias).exclude(codelink__exact=''):
+        media.code = media.codelink
+        media.save()
+
+
+def migrate_slideshare_links(apps, schema_editor):
+    TalkMedia = apps.get_model("talk", "TalkMedia")
+
+    http_session = requests.Session()
+
+    base_url = 'https://www.slideshare.net/slideshow/embed_code/key/'
+    db_alias = schema_editor.connection.alias
+    for media in TalkMedia.objects.using(db_alias).exclude(slideshare__exact=''):
+        response = http_session.get(base_url + media.slideshare)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, 'lxml')
+        link = soup('link', rel='canonical')[0]
+        media.slides = link.get('href')
+        media.save()
+
+
+def migrate_youtube_links(apps, schema_editor):
+    TalkMedia = apps.get_model("talk", "TalkMedia")
+
+    db_alias = schema_editor.connection.alias
+    for media in TalkMedia.objects.using(db_alias).exclude(youtube__exact=''):
+        media.video = "https://www.youtube.com/watch?v={}".format(media.youtube)
+        media.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('talk', '0045_use_links_for_talk_media_add_new_fields'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_code_links),
+        migrations.RunPython(migrate_slideshare_links),
+        migrations.RunPython(migrate_youtube_links),
+    ]

--- a/devday/talk/migrations/0047_use_links_for_talk_media_drop_old_fields.py
+++ b/devday/talk/migrations/0047_use_links_for_talk_media_drop_old_fields.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('talk', '0046_use_links_for_talk_media_migrate_content'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='talkmedia',
+            name='codelink',
+        ),
+        migrations.RemoveField(
+            model_name='talkmedia',
+            name='slideshare',
+        ),
+        migrations.RemoveField(
+            model_name='talkmedia',
+            name='youtube',
+        ),
+    ]

--- a/devday/talk/models.py
+++ b/devday/talk/models.py
@@ -266,15 +266,9 @@ def prevent_removal_of_last_published_speaker(sender, instance, action, **kwargs
 
 class TalkMedia(models.Model):
     talk = models.OneToOneField(Talk, related_name="media", on_delete=models.CASCADE)
-    youtube = models.CharField(
-        verbose_name=_("Youtube video id"), max_length=64, blank=True
-    )
-    slideshare = models.CharField(
-        verbose_name=_("Slideshare id"), max_length=64, blank=True
-    )
-    codelink = models.CharField(
-        verbose_name=_("Source code"), max_length=255, blank=True
-    )
+    video = models.URLField(verbose_name=_("Video"), blank=True)
+    slides = models.URLField(verbose_name=_("Slides"), blank=True)
+    code = models.URLField(verbose_name=_("Source code"), blank=True)
 
 
 class Vote(models.Model):

--- a/devday/talk/templates/talk/talk_details.html
+++ b/devday/talk/templates/talk/talk_details.html
@@ -35,40 +35,33 @@
                     </span></p>
                 {% endif %}
             {% endif %}
-            {% if talk.media.youtube %}
+            {% if talk.media.video %}
                 <div class="card">
                     <div class="card-header">
-                        <i class="fab fa-youtube" aria-hidden="true"></i>{% trans "Video" %}
+                        <i class="fab fa-video" aria-hidden="true"></i>{% trans "Video" %}
                     </div>
                     <div class="card-body">
-                        <iframe width="560" height="315"
-                            src="//www.youtube-nocookie.com/embed/{{ talk.media.youtube }}"
-                            frameborder="0"
-                            allowfullscreen></iframe>
+                        <a href="{{ talk.media.video }}" target="_blank">{{ talk.media.video }}</a>
                     </div>
                 </div>
             {% endif %}
-            {% if talk.media.slideshare %}
+            {% if talk.media.slides %}
                 <div class="card">
                     <div class="card-header">
                         <i class="fab fa-slideshare" aria-hidden="true"></i>{% trans "Slide deck" %}
                     </div>
                     <div class="card-body">
-                        <iframe width="595" height="485"
-                            src="https://www.slideshare.net/slideshow/embed_code/key/{{ talk.media.slideshare }}"
-                            frameborder="0" marginwidth="0"
-                            scrolling="no" style=""
-                            allowfullscreen></iframe>
+                        <a href="{{ talk.media.slides }}" target="_blank">{{ talk.media.slides }}</a>
                     </div>
                 </div>
             {% endif %}
-            {% if talk.media.codelink %}
+            {% if talk.media.code %}
                  <div class="card">
                     <div class="card-header">
                         <i class="fas fa-file-code" aria-hidden="true"></i>{% trans "Example code" %}
                     </div>
                     <div class="card-body">
-                        <a href="{{ talk.media.codelink }}">{{ talk.media.codelink }}</a>
+                        <a href="{{ talk.media.code }}" target="_blank">{{ talk.media.code }}</a>
                     </div>
                 </div>
             {% endif %}

--- a/devday/talk/templates/talk/talk_list_entry.html
+++ b/devday/talk/templates/talk/talk_list_entry.html
@@ -19,11 +19,10 @@
             <p>{{ talk.abstract|truncatechars:140 }}</p>
 
             <div class="media-list">
-                {% if talk.media.youtube %}<a href="{% url 'talk_details' event=talk.event.slug slug=talk.slug %}" title="Video"><i class="fab fa-youtube" aria-hidden="true"></i></a>{% endif %}
-                {% if talk.media.slideshare %}<a href="{% url 'talk_details' event=talk.event.slug slug=talk.slug %}" title="Slides"><i class="fab fa-slideshare" aria-hidden="true"></i></a>{% endif %}
-                {% if talk.media.codelink %}<a href="{% url 'talk_details' event=talk.event.slug slug=talk.slug %}" title="Code"><i class="fas fa-file-code" aria-hidden="true"></i></a>{% endif %}
+                {% if talk.media.video %}<a href="{% url 'talk_details' event=talk.event.slug slug=talk.slug %}" title="{% trans "Video" %}"><i class="fab fa-video" aria-hidden="true"></i></a>{% endif %}
+                {% if talk.media.slides %}<a href="{% url 'talk_details' event=talk.event.slug slug=talk.slug %}" title="{% trans "Slide Deck" %}"><i class="fab fa-slideshare" aria-hidden="true"></i></a>{% endif %}
+                {% if talk.media.code %}<a href="{% url 'talk_details' event=talk.event.slug slug=talk.slug %}" title="{% trans "Example code" %}"><i class="fas fa-file-code" aria-hidden="true"></i></a>{% endif %}
             </div>
-
         </div>
     </div>
 </div>

--- a/devday/talk/templates/talk/talk_videos.html
+++ b/devday/talk/templates/talk/talk_videos.html
@@ -21,24 +21,19 @@
                   {% endfor %}
                   <h4>Abstract</h4>
                   <p>{{ talk.abstract|striptags|urlize|linebreaksbr }}</p>
-                  {% if talk.media.youtube %}
-                    <div class="col-sm-6 col-xs-12">
-                      <iframe width="560" height="315"
-                              src="//www.youtube-nocookie.com/embed/{{ talk.media.youtube }}"
-                              frameborder="0" allowfullscreen></iframe>
-                    </div>
-                  {% endif %}
-                  {% if talk.media.slideshare %}
-                    <div class="col-sm-6 col-xs-12">
-                      <iframe width="595" height="485"
-                              src="https://www.slideshare.net/slideshow/embed_code/key/{{ talk.media.slideshare }}"
-                              frameborder="0" marginwidth="0" scrolling="no" style=""
-                              allowfullscreen></iframe>
-                    </div>
-                  {% endif %}
-                  {% if talk.media.codelink %}
+                  {% if talk.media.video %}
                     <div class="col-sm-12">
-                      {% trans "Example code" %}: <a href="{{ talk.media.codelink }}">{{ talk.media.codelink }}</a>
+                        {% trans "Video" %}: <a href="{{ talk.media.video }}">{{ talk.media.video }}</a>
+                    </div>
+                  {% endif %}
+                  {% if talk.media.slides %}
+                    <div class="col-sm-12">
+                        {% trans "Slide deck" %}: <a href="{{ talk.media.slides }}">{{ talk.media.slides }}</a>
+                    </div>
+                  {% endif %}
+                  {% if talk.media.code %}
+                    <div class="col-sm-12">
+                      {% trans "Example code" %}: <a href="{{ talk.media.code }}">{{ talk.media.code }}</a>
                     </div>
                   {% endif %}
                 </div>

--- a/devday/talk/tests/test_views.py
+++ b/devday/talk/tests/test_views.py
@@ -1104,10 +1104,10 @@ class TestTalkVideoView(TestCase):
         talk1.publish(track)
         talk2.publish(track)
         TalkMedia.objects.create(
-            talk=talk1, codelink="https://example.org/git/talk1code"
+            talk=talk1, code="https://example.org/git/talk1code"
         )
         TalkMedia.objects.create(
-            talk=talk2, codelink="https://example.org/git/talk1code"
+            talk=talk2, code="https://example.org/git/talk1code"
         )
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This commit switches the talk media support to using links instead of embedding. This allows us to use different providers for slides and videos. All fields have been changed to URL fields to get free URL validation from the Django admin interface. Migrations for the existing data have been implemented.