### PR TITLE
Use Slug for Session URL

### DIFF
--- a/devday/talk/api_views.py
+++ b/devday/talk/api_views.py
@@ -3,15 +3,24 @@ from rest_framework.relations import StringRelatedField
 from talk.models import Talk
 
 
-class SessionSerializer(serializers.ModelSerializer):
+class SessionSerializer(serializers.HyperlinkedModelSerializer):
+    id = serializers.CharField(source="slug")
+    description = serializers.CharField(source="abstract")
+
+    # TODO Jens: Replace 'event' and 'speakers' with proper nested relationships once their endpoints are done.
     event = StringRelatedField()
-    published_speaker = StringRelatedField()
+    published_speakers = StringRelatedField(many=True)
 
     class Meta:
         model = Talk
-        fields = ["url", "title", "abstract", "published_speakers", "event"]
+        fields = ["id", "url", "title", "description", "published_speakers", "event"]
+        lookup_field = "slug"
+        extra_kwargs = {
+            "url": {'lookup_field': 'slug'}
+        }
 
 
 class SessionViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Talk.objects.filter(published_speakers__isnull=False)
     serializer_class = SessionSerializer
+    lookup_field = 'slug'


### PR DESCRIPTION
Minor update to the existing code for the session list. The only real
change is that the "id" is now the slug of the Talk and the "url" uses
the talks slug instead of the pk.

Further improvements will be made to the serializer, once the other
endpoints/serializers are done.

The output of `/api/sessions` looks now like this:

```json
[
    {
        "id": "acheing-a-internally-attached-limit",
        "url": "http://localhost:8000/api/sessions/acheing-a-internally-attached-limit/",
        "title": "Acheing A Internally Attached Limit",
        "description": "Magnam tempora sit quaerat sit amet. Dolorem ut quiquia magnam quisquam. Consectetur sit consectetur tempora est amet. Voluptatem sed dolor voluptatem sed adipisci porro. Adipisci neque non velit dolorem. Quaerat ipsum dolore adipisci sit labore consectetur quisquam.",
        "published_speakers": [
            "Jana Vogel (devdata.18)"
        ],
        "event": "devdata.18"
    },
    {
        "id": "affirming-a-wetly-querulous-bill",
        "url": "http://localhost:8000/api/sessions/affirming-a-wetly-querulous-bill/",
        "title": "Affirming A Wetly Querulous Bill",
        "description": "Sit modi etincidunt voluptatem. Dolor est magnam neque consectetur sed est tempora. Sit dolorem aliquam modi. Voluptatem amet ipsum sed sed voluptatem sed. Dolorem etincidunt ut modi dolore velit. Consectetur tempora ipsum voluptatem dolore adipisci tempora ipsum. Eius sed modi non adipisci adipisci dolorem neque. Ipsum adipisci dolorem ut quisquam eius. Amet etincidunt aliquam non neque.",
        "published_speakers": [
            "Natalie Lehmann (devdata.17)"
        ],
        "event": "devdata.17"
    }
]
```

Part of issue #220 