### PR TITLE
Add Initial Speakers Endpoint

### DIFF
--- a/devday/devday/urls.py
+++ b/devday/devday/urls.py
@@ -9,6 +9,8 @@ from django.views.static import serve as serve_static
 
 from devday.views import SendEmailView, exception_test_view
 from rest_framework import routers
+
+from speaker.api_views import SpeakerViewSet
 from talk.api_views import SessionViewSet
 from twitterfeed.views import TwitterwallView
 
@@ -16,6 +18,7 @@ admin.autodiscover()
 
 router = routers.DefaultRouter()
 router.register(r"sessions", SessionViewSet)
+router.register(r"speakers", SpeakerViewSet)
 
 urlpatterns = [
     url(r"^api/", include(router.urls)),

--- a/devday/speaker/api_views.py
+++ b/devday/speaker/api_views.py
@@ -1,0 +1,31 @@
+from rest_framework import serializers, viewsets
+
+from speaker.models import Speaker
+
+
+class SpeakerSerializer(serializers.HyperlinkedModelSerializer):
+    id = serializers.CharField(source="slug")
+    image = serializers.ImageField(source="public_image", use_url=True, allow_null=False, allow_empty_file=False)
+
+    class Meta:
+        model = Speaker
+        fields = ["id", "url", "name", "short_biography", "position", "image"]
+        lookup_field = "slug"
+        extra_kwargs = {
+            "url": {'lookup_field': 'slug'}
+        }
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        # TODO Jens: This probably can be solved more elegantly with a mixin.
+        if not representation["image"]:
+            representation["image"] = ""
+
+        return representation
+
+
+class SpeakerViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Speaker.objects.all()
+    serializer_class = SpeakerSerializer
+    lookup_field = "slug"

--- a/devday/talk/api_views.py
+++ b/devday/talk/api_views.py
@@ -3,15 +3,24 @@ from rest_framework.relations import StringRelatedField
 from talk.models import Talk
 
 
-class SessionSerializer(serializers.ModelSerializer):
+class SessionSerializer(serializers.HyperlinkedModelSerializer):
+    id = serializers.CharField(source="slug")
+    description = serializers.CharField(source="abstract")
+
+    # TODO Jens: Replace 'event' and 'speakers' with proper nested relationships once their endpoints are done.
     event = StringRelatedField()
-    published_speaker = StringRelatedField()
+    published_speakers = StringRelatedField(many=True)
 
     class Meta:
         model = Talk
-        fields = ["url", "title", "abstract", "published_speakers", "event"]
+        fields = ["id", "url", "title", "description", "published_speakers", "event"]
+        lookup_field = "slug"
+        extra_kwargs = {
+            "url": {'lookup_field': 'slug'}
+        }
 
 
 class SessionViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Talk.objects.filter(published_speakers__isnull=False)
     serializer_class = SessionSerializer
+    lookup_field = 'slug'


### PR DESCRIPTION
Note: This PR is stacked on top of #272 

The endpoint outputs basic information about speakers, including an
endpoint for speaker details. At the moment there is no relationship to
other entities yet. This will be added at a later point in time, like
for example the talks the speaker has given or will give or the events
the speaker presented at.

I have changed the serialisation of the `image` field to show an empty string instead of `null`.

Example output of `/api/speakers`:

```json
[
    {
        "id": "ingo-albrecht",
        "url": "http://localhost:8000/api/speakers/ingo-albrecht/",
        "name": "Ingo Albrecht",
        "short_biography": "My short bio",
        "position": "",
        "image": ""
    },
    {
        "id": "alexander-richter",
        "url": "http://localhost:8000/api/speakers/alexander-richter/",
        "name": "Alexander Richter",
        "short_biography": "My short bio",
        "position": "",
        "image": "http://localhost:8000/media/speaker_public/0c4aeb7a06d7f7e33587b997c509a0d73faa1cb3dc04ec56a6698725_thumbnail.png"
    }
]
```