### PR TITLE
Add 'events' API Endpoint

### DIFF
--- a/devday/devday/urls.py
+++ b/devday/devday/urls.py
@@ -10,6 +10,7 @@ from django.views.static import serve as serve_static
 from devday.views import SendEmailView, exception_test_view
 from rest_framework import routers
 
+from event.api_views import EventDetailViewSet
 from speaker.api_views import SpeakerViewSet
 from talk.api_views import SessionViewSet
 from twitterfeed.views import TwitterwallView
@@ -19,6 +20,7 @@ admin.autodiscover()
 router = routers.DefaultRouter()
 router.register(r"sessions", SessionViewSet)
 router.register(r"speakers", SpeakerViewSet)
+router.register(r"events", EventDetailViewSet)
 
 urlpatterns = [
     url(r"^api/", include(router.urls)),

--- a/devday/event/api_views.py
+++ b/devday/event/api_views.py
@@ -1,0 +1,22 @@
+from rest_framework import serializers, viewsets
+
+from event.models import Event
+
+
+class EventSerializer(serializers.ModelSerializer):
+    id = serializers.CharField(source="slug")
+    full_day_event = serializers.BooleanField(source='full_day')
+
+    class Meta:
+        model = Event
+        fields = ["id", "url", "location", "title", "description", "full_day_event", "start_time", "end_time"]
+        lookup_field = "slug"
+        extra_kwargs = {
+            "url": {'lookup_field': 'slug'}
+        }
+
+
+class EventDetailViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Event.objects.filter(published=True)
+    serializer_class = EventSerializer
+    lookup_field = 'slug'


### PR DESCRIPTION
The is a draft of a possible Events API. Not all fields of the Event
model are exposed. This is by design, to not over-expose too much
information, that nobody needs.

This will be developed over time. One good extension might be to add
links to all the sessions associated with the event.

Furthermore, the API could be extended by "actions". Links that can be
followed to for example register for an event etc.

Example output of `/api/events`:

```json
[
    {
        "id": "devdata17",
        "url": "http://localhost:8000/api/events/devdata17/",
        "location": "Dresden",
        "title": "devdata.17",
        "description": "Dev Data.17 am 4.4. in Dresden",
        "full_day_event": false,
        "start_time": "2017-04-04T13:00:00+02:00",
        "end_time": "2017-04-04T20:00:00+02:00"
    },
    {
        "id": "devdata18",
        "url": "http://localhost:8000/api/events/devdata18/",
        "location": "Dresden",
        "title": "devdata.18",
        "description": "Dev Data.18 am 24.4. in Dresden",
        "full_day_event": false,
        "start_time": "2018-04-24T13:00:00+02:00",
        "end_time": "2018-04-24T20:00:00+02:00"
    }
]
```

@jandd Not sure if the selection of the fields is sufficient. I did not want to expose all the fields right away. Anything that is missing that we definitely need to have in this PR?

As before, once we have this merged I can start integrating speakers/events/sessions into each other.