### PR TITLE
Add Speaker Information to Sessions API

### DIFF
--- a/devday/talk/api_views.py
+++ b/devday/talk/api_views.py
@@ -1,6 +1,29 @@
 from rest_framework import serializers, viewsets
 from rest_framework.relations import StringRelatedField
+
+from speaker.models import Speaker
 from talk.models import Talk
+
+
+class NestedSpeakersSerializer(serializers.ModelSerializer):
+    image = serializers.ImageField(source="thumbnail")
+
+    class Meta:
+        model = Speaker
+        fields = ["url", "name", "image"]
+        lookup_field = "slug"
+        extra_kwargs = {
+            "url": {'lookup_field': 'slug'}
+        }
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        # TODO Jens: This probably can be solved more elegantly with a mixin.
+        if not representation["image"]:
+            representation["image"] = ""
+
+        return representation
 
 
 class SessionSerializer(serializers.HyperlinkedModelSerializer):
@@ -9,11 +32,11 @@ class SessionSerializer(serializers.HyperlinkedModelSerializer):
 
     # TODO Jens: Replace 'event' and 'speakers' with proper nested relationships once their endpoints are done.
     event = StringRelatedField()
-    published_speakers = StringRelatedField(many=True)
+    speakers = NestedSpeakersSerializer(source="published_speakers", many=True, read_only=True)
 
     class Meta:
         model = Talk
-        fields = ["id", "url", "title", "description", "published_speakers", "event"]
+        fields = ["id", "url", "title", "description", "speakers", "event"]
         lookup_field = "slug"
         extra_kwargs = {
             "url": {'lookup_field': 'slug'}


### PR DESCRIPTION
Instead of just containing a list of speaker names, after this patch is
applied, the API will contain a list of objects. Object object per
(published) speaker. The object will contain a URL to the speakers
details (in the API), the name of the speaker and image URL of the
speakers thumbnail.

Notes:

1. The `image` is the thumbnail. If I should use the `portrait` or `public_image` of the speaker please let me know.
2. As before, instead of serialising as `null`, if the image is not set it is serialised as empty string.

Example output of `/api/sessions`:

```json
[
    {
        "id": "acheing-a-internally-attached-limit",
        "url": "http://localhost:8000/api/sessions/acheing-a-internally-attached-limit/",
        "title": "Acheing A Internally Attached Limit",
        "description": "Magnam ut sit est neque. Etincidunt labore tempora quaerat quisquam tempora etincidunt etincidunt. Consectetur consectetur velit ipsum quaerat modi ut sed. Est aliquam sed voluptatem non magnam amet. Modi tempora neque sit labore quiquia quaerat. Dolore sed quiquia sit est velit sed. Voluptatem amet est est labore porro. Numquam numquam ipsum dolore. Tempora quaerat labore velit modi eius amet labore.",
        "speakers": [
            {
                "url": "http://localhost:8000/api/speakers/jana-vogel/",
                "name": "Jana Vogel",
                "image": "http://localhost:8000/media/speaker/devdata18/thumbs/0c4aeb7a06d7f7e33587b997c509a0d73faa1cb3dc04ec56a6698725_thumbnail.png"
            }
        ],
        "event": "devdata.18"
    },
    {
        "id": "affirming-a-wetly-querulous-bill",
        "url": "http://localhost:8000/api/sessions/affirming-a-wetly-querulous-bill/",
        "title": "Affirming A Wetly Querulous Bill",
        "description": "Sed adipisci labore etincidunt numquam modi tempora tempora. Velit dolor numquam etincidunt dolore amet. Ut magnam sit ipsum. Numquam ut quaerat dolor tempora consectetur sed modi. Dolore magnam velit etincidunt sed. Velit quisquam est adipisci ut sit sed ut.",
        "speakers": [
            {
                "url": "http://localhost:8000/api/speakers/natalie-lehmann/",
                "name": "Natalie Lehmann",
                "image": ""
            }
        ],
        "event": "devdata.17"
    }
]
```