### PR TITLE
Change Favourite Behaviour to Use PUT/DELETE

### DIFF
--- a/devday/talk/api_views.py
+++ b/devday/talk/api_views.py
@@ -48,7 +48,7 @@ class SessionSerializer(serializers.HyperlinkedModelSerializer):
         ret = super().to_representation(instance)
 
         ret["actions"] = {
-            "favourite": ret["url"] + "favourite"
+            "favourite": ret["url"] + "favourite/"
         }
 
         return ret

--- a/devday/talk/api_views.py
+++ b/devday/talk/api_views.py
@@ -48,8 +48,7 @@ class SessionSerializer(serializers.HyperlinkedModelSerializer):
         ret = super().to_representation(instance)
 
         ret["actions"] = {
-            "favourite": ret["url"] + "favourite",
-            "unfavourite": ret["url"] + "unfavourite"
+            "favourite": ret["url"] + "favourite"
         }
 
         return ret
@@ -60,8 +59,8 @@ class SessionViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = SessionSerializer
     lookup_field = 'slug'
 
-    @action(detail=True, methods=['post'])
-    def favourite(self, request, slug):
+    @action(detail=True, methods=['put'])
+    def favourite(self, request, slug=None):
         session = self.get_object()
         user = request.user
         user.favourite_talks.add(session)
@@ -69,8 +68,8 @@ class SessionViewSet(viewsets.ReadOnlyModelViewSet):
 
         return Response(status=status.HTTP_201_CREATED)
 
-    @action(detail=True, methods=['post'])
-    def unfavourite(self, request, slug):
+    @favourite.mapping.delete
+    def delete_favourite(self, request, slug=None):
         session = self.get_object()
         user = request.user
         user.favourite_talks.remove(session)


### PR DESCRIPTION
Minor change as proposed by Jan to not have separate endpoints to
favourite/unfavourite sessions, but to use PUT/DELETE on the same
endpoint.

Now the output of `/api/sessions/` and `/api/sessions/<session-name>/` looks like this:

```
[
    {
        "id": "acheing-a-internally-attached-limit",
        "url": "http://localhost:8000/api/sessions/acheing-a-internally-attached-limit/",
        "title": "Acheing A Internally Attached Limit",
        "description": "Dolor quisquam modi magnam sit sed. Modi velit neque dolor. Voluptatem consectetur dolorem ipsum amet quaerat adipisci. Ut quiquia numquam adipisci. Modi tempora quisquam quiquia.",
        "speakers": [
            {
                "url": "http://localhost:8000/api/speakers/jana-vogel/",
                "name": "Jana Vogel",
                "image": ""
            }
        ],
        "event": "devdata.18",
        "actions": {
            "favourite": "http://localhost:8000/api/sessions/acheing-a-internally-attached-limit/favourite"
        }
    }
]
```

Run `PUT http://localhost:8000/api/sessions/acheing-a-internally-attached-limit/favourite` to favourite a session and `DELETE http://localhost:8000/api/sessions/acheing-a-internally-attached-limit/favourite` to unfavourite it.