### PR TITLE
Enable Token Authentication for API

### DIFF
--- a/devday/devday/settings/__init__.py
+++ b/devday/devday/settings/__init__.py
@@ -186,6 +186,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.contrib.messages",
     "rest_framework",
+    "rest_framework.authtoken",
     "devday.apps.DevDayApp",
     "event.apps.EventsConfig",
     "attendee.apps.AttendeeConfig",
@@ -240,6 +241,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.BasicAuthentication",
         "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.TokenAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
 }

--- a/devday/devday/urls.py
+++ b/devday/devday/urls.py
@@ -9,6 +9,7 @@ from django.views.static import serve as serve_static
 
 from devday.views import SendEmailView, exception_test_view
 from rest_framework import routers
+from rest_framework.authtoken import views
 
 from event.api_views import EventDetailViewSet
 from speaker.api_views import SpeakerViewSet
@@ -25,6 +26,7 @@ router.register(r"events", EventDetailViewSet)
 urlpatterns = [
     url(r"^api/", include(router.urls)),
     url(r"^api-auth/", include("rest_framework.urls")),
+    url(r"^api-token-auth/", views.obtain_auth_token),
     url(r"^admin/", admin.site.urls),
     url(r"^admin/send_email/$", SendEmailView.as_view(), name="send_email"),
     url(r"^sitemap\.xml$", sitemap_view, {"sitemaps": {"cmspages": CMSSitemap}}),


### PR DESCRIPTION
---
⚠️ This PR will require a database migration after the deployment.

---

Minor change to enable Token authentication for our API. This is meant
to enable applications that do not want to use the typical
username/password authentication scheme using an underlying session.

Tokens can be requested using the http(s) endpoint `/api-token-auth/` by issuing a POST request containing the username and password as payload.

```shell
curl \
    --location \
    --request POST \
    'http(s)://<host>/api-token-auth/' \
    --form 'username="<username>"' \
    --form 'password="<password>"'
```

The returned token then can be used to issue HTTP requests to the API by passing a `Authentication` header like the following:

```
Authentication: Token <token>
```

Example:

```shell
curl \
    --request GET http(s)://<host>/api/sessions/ \
    --header 'Authorization: Token <token>'
```

Relevant documentation: https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication