### PR TITLE
Fix talk admin 404

### DIFF
--- a/devday/talk/admin.py
+++ b/devday/talk/admin.py
@@ -91,7 +91,9 @@ class TalkPublishedSpeakerInline(PrefetchAdmin, admin.StackedInline):
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         field = super().formfield_for_foreignkey(db_field, request, **kwargs)
-        field.queryset = field.queryset.filter(event__exact=request._obj_.event)
+        if request._obj_:
+            event = request._obj_.event
+            field.queryset = field.queryset.filter(event__exact=event)
         return field
 
 


### PR DESCRIPTION
Fix a bug that results in 404 when creating a new talk via admin.